### PR TITLE
Qdl 4 corrigir inclusao form pergunta

### DIFF
--- a/app/Http/Livewire/ButtonBackForm.php
+++ b/app/Http/Livewire/ButtonBackForm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+
+class ButtonBackForm extends Component
+{
+    public $route;
+
+    public function mount($route){
+        $this->route = $route;
+    }
+
+    public function render()
+    {
+        return view('livewire.button-back-form');
+    }
+}

--- a/app/Http/Livewire/ButtonConfirmForm.php
+++ b/app/Http/Livewire/ButtonConfirmForm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+
+class ButtonConfirmForm extends Component
+{
+    public $action;
+
+    public function mount($action){
+        $this->action = $action;
+    }
+
+    public function render()
+    {
+        return view('livewire.button-confirm-form');
+    }
+}

--- a/resources/views/livewire/button-back-form.blade.php
+++ b/resources/views/livewire/button-back-form.blade.php
@@ -1,0 +1,5 @@
+<div style="text-align: center;">
+    <a href="{{ $route }}">
+        <button class="btn btn-outline btn-info">Voltar</button>
+    </a>
+</div>

--- a/resources/views/livewire/button-confirm-form.blade.php
+++ b/resources/views/livewire/button-confirm-form.blade.php
@@ -1,0 +1,7 @@
+<div style="text-align: center;">
+    @if(in_array($action, ['incluir', 'alterar']))
+        <button type="submit" class="btn btn-outline btn-success">Salvar</button>
+    @elseif($action == 'excluir')
+        <button type="submit" class="btn btn-outline btn-error">Confirmar Exclusão</button>
+    @endif
+</div>

--- a/resources/views/livewire/pergunta/form.blade.php
+++ b/resources/views/livewire/pergunta/form.blade.php
@@ -1,5 +1,5 @@
 <div>
-
+    @livewire('button-back-form', ['/pergunta'])
     <div class="card m-5 bg-base-100 shadow-xl">
         <div class="card-body">
             <form wire:submit.prevent="save">
@@ -44,7 +44,7 @@
                     <div></div>
                     <div></div>
                     <div></div>
-                    <button wire:click="back" class="btn btn-outline btn-info">Voltar</button>
+                    <!-- <button wire:click="back" class="btn btn-outline btn-info">Voltar</button> -->
                     <button type="submit" class="btn btn-outline btn-success">Salvar</button>
                 </div>
             </form>

--- a/resources/views/livewire/pergunta/form.blade.php
+++ b/resources/views/livewire/pergunta/form.blade.php
@@ -39,14 +39,15 @@
                 </div>
                 @endif
 
-                <div class="grid grid-cols-6">
+                @livewire('button-confirm-form', [$action])
+                <!-- <div class="grid grid-cols-6">
                     <div></div>
                     <div></div>
                     <div></div>
                     <div></div>
-                    <!-- <button wire:click="back" class="btn btn-outline btn-info">Voltar</button> -->
+                    <button wire:click="back" class="btn btn-outline btn-info">Voltar</button>
                     <button type="submit" class="btn btn-outline btn-success">Salvar</button>
-                </div>
+                </div> -->
             </form>
         </div>
     </div>


### PR DESCRIPTION
Criado um componente de botão de voltar, na tela do formulário, onde o botão fica fora do form e desse modo quando clicado não submete o form, e sim somente retorna para a rota passada no construtor.

E fica também de padrão para utilização do Crud, se precisar alterar o botão de voltar de todos os formulários muda em um unico lugar.
--------------------------------------------
Criado um componente para os botões de submissão do form, onde todo form vai chamar esse componente e passar o tipo do form(incluir, visual, alterar, excluir) e esse componente mostrará o botão correto a se utillizar para cada cenário.